### PR TITLE
Fix compilation error on ARM64 architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - upgrade libraries versions
 - correction of technical problem with Integration tests (because of Maven format in technical answer to "sonar-orchestrator-junit5" library)
 - update from jdk 11 to 17
+- Add Lombok annotation processing inside `maven-compiler` plugin, to fix compile error on Arm64 architecture
 
 ### Deleted
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 <!--        <sonarpython.version>5.4.0.22255</sonarpython.version>-->
 
          <mockito.version>5.17.0</mockito.version>
+        <lombok.version>1.18.38</lombok.version>
 
         <!-- temporary version waiting for a real automatic release in creedengo repository -->
         <creedengo-rules-specifications.version>2.2.2</creedengo-rules-specifications.version>
@@ -176,7 +177,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.38</version>
+            <version>${lombok.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -189,6 +190,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.14.0</version>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.projectlombok</groupId>
+                            <artifactId>lombok</artifactId>
+                            <version>${lombok.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
### Problem
Compilation error when building on ARM64 (MacOS) due to missing Lombok annotation processing.

### Solution
Added Lombok annotation processor configuration to maven-compiler-plugin as per [Lombok documentation](https://projectlombok.org/setup/maven).

### Testing
✅ Compiles successfully on ARM64 (MacOS)
✅ Verified compatibility with AMD64 (Ubuntu VM)