### PR TITLE
Rules/gci24 avoid unlimited sql request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add rule GCI24: Returned SQL results should be limited (avoid SELECT...FROM without LIMIT)
+
 ### Changed
 
 - upgrade internal libraries versions
@@ -18,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.3.0] - 2026-03-06
 
 ### Added
+
 - [#110](https://github.com/green-code-initiative/creedengo-python/issues/110) Correction of NullPointerException in GCI2 rule
 - [#82](https://github.com/green-code-initiative/creedengo-python/pull/82) Add rule GCI112 @dataclass(slots=True) should be declared on data classes
 - [#108](https://github.com/green-code-initiative/creedengo-python/pull/108) Add rule GCI109 Avoid using exceptions for control flow

--- a/src/it/java/org/greencodeinitiative/creedengo/python/integration/tests/GCIRulesIT.java
+++ b/src/it/java/org/greencodeinitiative/creedengo/python/integration/tests/GCIRulesIT.java
@@ -58,6 +58,19 @@ class GCIRulesIT extends GCIRulesBase {
     }
 
     @Test
+    void testGCI24() {
+
+        String filePath = "src/avoidUnlimitedSQLRequest.py";
+        String ruleId = "creedengo-python:GCI24";
+        String ruleMsg = "Don't use the query SELECT _ FROM _ WHERE _ without a limit";
+        int[] startLines = new int[]{4, 7};
+        int[] endLines = new int[]{4, 7};
+
+        checkIssuesForFile(filePath, ruleId, ruleMsg, startLines, endLines, SEVERITY_MAJOR, TYPE, EFFORT_15MIN);
+
+    }
+
+    @Test
     void testGCI7_compliant() {
 
         String filePath = "src/avoidGettersAndSettersCompliant.py";

--- a/src/it/java/org/greencodeinitiative/creedengo/python/integration/tests/GCIRulesIT.java
+++ b/src/it/java/org/greencodeinitiative/creedengo/python/integration/tests/GCIRulesIT.java
@@ -62,7 +62,7 @@ class GCIRulesIT extends GCIRulesBase {
 
         String filePath = "src/avoidUnlimitedSQLRequest.py";
         String ruleId = "creedengo-python:GCI24";
-        String ruleMsg = "Don't use the query SELECT _ FROM _ WHERE _ without a limit";
+        String ruleMsg = "Don't use a SELECT _ FROM _ query without a limit";
         int[] startLines = new int[]{4, 7};
         int[] endLines = new int[]{4, 7};
 

--- a/src/it/test-projects/creedengo-python-plugin-test-project/src/avoidUnlimitedSQLRequest.py
+++ b/src/it/test-projects/creedengo-python-plugin-test-project/src/avoidUnlimitedSQLRequest.py
@@ -1,0 +1,10 @@
+def display_message(argument1):
+    print(argument1)
+
+display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant
+display_message('   sElEcT user fRoM myTable WhErE id > 0 LiMiT 10')
+
+requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant
+requestCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0 LiMiT 10'
+display_message(requestNonCompiliant)
+display_message(requestCompiliant)

--- a/src/it/test-projects/creedengo-python-plugin-test-project/src/avoidUnlimitedSQLRequest.py
+++ b/src/it/test-projects/creedengo-python-plugin-test-project/src/avoidUnlimitedSQLRequest.py
@@ -1,10 +1,10 @@
 def display_message(argument1):
     print(argument1)
 
-display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant
+display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant {{Don't use a SELECT _ FROM _ query without a limit}}
 display_message('   sElEcT user fRoM myTable WhErE id > 0 LiMiT 10')
 
-requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant
+requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant {{Don't use a SELECT _ FROM _ query without a limit}}
 requestCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0 LiMiT 10'
 display_message(requestNonCompiliant)
 display_message(requestCompiliant)

--- a/src/main/java/org/greencodeinitiative/creedengo/python/PythonRuleRepository.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/PythonRuleRepository.java
@@ -34,6 +34,7 @@ public record PythonRuleRepository(SonarRuntime sonarRuntime) implements RulesDe
             AvoidSQLRequestInLoop.class,
             AvoidTryCatchWithFileOpenedCheck.class,
             AvoidUnlimitedCache.class,
+            AvoidUnlimitedSQLRequest.class,
             AvoidUnoptimizedVectorImagesCheck.class,
             AvoidFullSQLRequest.class,
             AvoidListComprehensionInIterations.class,

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
@@ -1,0 +1,73 @@
+/*
+ * creedengo - Python language - Provides rules to reduce the environmental footprint of your Python programs
+ * Copyright © 2024 Green Code Initiative (https://green-code-initiative.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.greencodeinitiative.creedengo.python.checks;
+
+import org.sonar.plugins.python.api.PythonSubscriptionCheck;
+import org.sonar.plugins.python.api.SubscriptionContext;
+import org.sonar.plugins.python.api.tree.StringElement;
+import org.sonar.plugins.python.api.tree.StringLiteral;
+import org.sonar.plugins.python.api.tree.Tree;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+public abstract class AbstractSQLPatternCheck extends PythonSubscriptionCheck {
+
+    private static final Map<String, Collection<Integer>> linesWithIssuesByFile = new HashMap<>();
+
+    protected abstract String getMessageRule();
+    
+    protected abstract Pattern getPattern();
+
+    @Override
+    public void initialize(Context context) {
+        context.registerSyntaxNodeConsumer(Tree.Kind.STRING_LITERAL, this::visitNodeString);
+    }
+
+    public void visitNodeString(SubscriptionContext ctx) {
+        StringLiteral stringLiteral = (StringLiteral) ctx.syntaxNode();
+        stringLiteral.stringElements().forEach(stringElement -> checkIssue(stringElement, ctx));
+    }
+
+    public void checkIssue(StringElement stringElement, SubscriptionContext ctx) {
+        if (lineAlreadyHasThisIssue(stringElement, ctx)) return;
+
+        if (getPattern().matcher(stringElement.value()).matches()) {
+            report(stringElement, ctx);
+        }
+    }
+
+    private void report(StringElement stringElement, SubscriptionContext ctx) {
+        if (stringElement.firstToken() != null) {
+            final String classname = ctx.pythonFile().fileName();
+            final int line = stringElement.firstToken().line();
+            linesWithIssuesByFile.computeIfAbsent(classname, k -> new ArrayList<>()).add(line);
+        }
+        ctx.addIssue(stringElement, getMessageRule());
+    }
+
+    private boolean lineAlreadyHasThisIssue(StringElement stringElement, SubscriptionContext ctx) {
+        final String classname = ctx.pythonFile().fileName();
+        final int line = stringElement.firstToken() != null ? stringElement.firstToken().line() : -1;
+        return linesWithIssuesByFile.getOrDefault(classname, new ArrayList<>()).contains(line);
+    }
+}

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
@@ -32,7 +32,7 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractSQLPatternCheck extends PythonSubscriptionCheck {
 
-    private static final Map<String, Collection<Integer>> linesWithIssuesByFile = new HashMap<>();
+    private final Map<String, Collection<Integer>> linesWithIssuesByFile = new HashMap<>();
 
     protected abstract String getMessageRule();
     

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AbstractSQLPatternCheck.java
@@ -24,15 +24,16 @@ import org.sonar.plugins.python.api.tree.StringElement;
 import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 public abstract class AbstractSQLPatternCheck extends PythonSubscriptionCheck {
 
-    private final Map<String, Collection<Integer>> linesWithIssuesByFile = new HashMap<>();
+    private final Map<String, Set<Integer>> linesWithIssuesByFile = new HashMap<>();
 
     protected abstract String getMessageRule();
     
@@ -60,7 +61,7 @@ public abstract class AbstractSQLPatternCheck extends PythonSubscriptionCheck {
         if (stringElement.firstToken() != null) {
             final String classname = ctx.pythonFile().fileName();
             final int line = stringElement.firstToken().line();
-            linesWithIssuesByFile.computeIfAbsent(classname, k -> new ArrayList<>()).add(line);
+            linesWithIssuesByFile.computeIfAbsent(classname, k -> new HashSet<>()).add(line);
         }
         ctx.addIssue(stringElement, getMessageRule());
     }
@@ -68,6 +69,6 @@ public abstract class AbstractSQLPatternCheck extends PythonSubscriptionCheck {
     private boolean lineAlreadyHasThisIssue(StringElement stringElement, SubscriptionContext ctx) {
         final String classname = ctx.pythonFile().fileName();
         final int line = stringElement.firstToken() != null ? stringElement.firstToken().line() : -1;
-        return linesWithIssuesByFile.getOrDefault(classname, new ArrayList<>()).contains(line);
+        return linesWithIssuesByFile.getOrDefault(classname, Collections.emptySet()).contains(line);
     }
 }

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidFullSQLRequest.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidFullSQLRequest.java
@@ -29,7 +29,7 @@ public class AvoidFullSQLRequest extends AbstractSQLPatternCheck {
 
     private static final String MESSAGE_RULE = "Don't use the query SELECT * FROM";
 
-    private static final Pattern PATTERN = Pattern.compile("(?i).*select.*\\*.*from.*");
+    private static final Pattern PATTERN = Pattern.compile("(?i).*\\bselect\\b.*\\*.*\\bfrom\\b.*");
 
     @Override
     protected String getMessageRule() {

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequest.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequest.java
@@ -1,0 +1,41 @@
+/*
+ * creedengo - Python language - Provides rules to reduce the environmental footprint of your Python programs
+ * Copyright © 2024 Green Code Initiative (https://green-code-initiative.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.greencodeinitiative.creedengo.python.checks;
+
+import org.sonar.check.Rule;
+
+import java.util.regex.Pattern;
+
+@Rule(key = "GCI24")
+public class AvoidUnlimitedSQLRequest extends AbstractSQLPatternCheck {
+
+    private static final String MESSAGE_RULE = "Don't use the query SELECT _ FROM _ WHERE _ without a limit";
+
+    private static final Pattern PATTERN = Pattern.compile("(?i).*select.*from(?!.*\\blimit\\b).*");
+
+    @Override
+    protected String getMessageRule() {
+        return MESSAGE_RULE;
+    }
+
+    @Override
+    protected Pattern getPattern() {
+        return PATTERN;
+    }
+}

--- a/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequest.java
+++ b/src/main/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequest.java
@@ -25,9 +25,9 @@ import java.util.regex.Pattern;
 @Rule(key = "GCI24")
 public class AvoidUnlimitedSQLRequest extends AbstractSQLPatternCheck {
 
-    private static final String MESSAGE_RULE = "Don't use the query SELECT _ FROM _ WHERE _ without a limit";
+    private static final String MESSAGE_RULE = "Don't use a SELECT _ FROM _ query without a limit";
 
-    private static final Pattern PATTERN = Pattern.compile("(?i).*select.*from(?!.*\\blimit\\b).*");
+    private static final Pattern PATTERN = Pattern.compile("(?i).*\\bselect\\b.*\\bfrom\\b(?!.*\\blimit\\b).*");
 
     @Override
     protected String getMessageRule() {

--- a/src/main/resources/org/greencodeinitiative/creedengo/python/creedengo_way_profile.json
+++ b/src/main/resources/org/greencodeinitiative/creedengo/python/creedengo_way_profile.json
@@ -6,6 +6,7 @@
 		"GCI4",
 		"GCI7",
 		"GCI10",
+		"GCI24",
 		"GCI35",
 		"GCI72",
 		"GCI74",

--- a/src/test/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequestTest.java
+++ b/src/test/java/org/greencodeinitiative/creedengo/python/checks/AvoidUnlimitedSQLRequestTest.java
@@ -1,0 +1,29 @@
+/*
+ * creedengo - Python language - Provides rules to reduce the environmental footprint of your Python programs
+ * Copyright © 2024 Green Code Initiative (https://green-code-initiative.org)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.greencodeinitiative.creedengo.python.checks;
+
+import org.junit.jupiter.api.Test;
+import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+public class AvoidUnlimitedSQLRequestTest {
+    @Test
+    public void test() {
+        PythonCheckVerifier.verify("src/test/resources/checks/avoidUnlimitedSQLRequest.py", new AvoidUnlimitedSQLRequest());
+    }
+}

--- a/src/test/resources/checks/avoidFullSQLRequest.py
+++ b/src/test/resources/checks/avoidFullSQLRequest.py
@@ -3,6 +3,16 @@ def display_message(argument1):
 
 display_message('   sElEcT * fRoM myTable') # Noncompliant {{Don't use the query SELECT * FROM}}
 display_message('   sElEcT user fRoM myTable')
+
+display_message(""" # Noncompliant {{Don't use the query SELECT * FROM}}
+    SELECT *
+    FROM myTable
+""")
+
+display_message("""
+    SELECT user
+    FROM myTable
+""")
   
 requestNonCompiliant = '   SeLeCt * FrOm myTable' # Noncompliant {{Don't use the query SELECT * FROM}}
 requestCompiliant = '   SeLeCt user FrOm myTable' 

--- a/src/test/resources/checks/avoidUnlimitedSQLRequest.py
+++ b/src/test/resources/checks/avoidUnlimitedSQLRequest.py
@@ -1,0 +1,10 @@
+def display_message(argument1):
+    print(argument1)
+
+display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant {{Don't use the query SELECT _ FROM _ WHERE _ without a limit}}
+display_message('   sElEcT user fRoM myTable WhErE id > 0 LiMiT 10')
+
+requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant {{Don't use the query SELECT _ FROM _ WHERE _ without a limit}}
+requestCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0 LiMiT 10'
+display_message(requestNonCompiliant)
+display_message(requestCompiliant)

--- a/src/test/resources/checks/avoidUnlimitedSQLRequest.py
+++ b/src/test/resources/checks/avoidUnlimitedSQLRequest.py
@@ -1,10 +1,21 @@
 def display_message(argument1):
     print(argument1)
 
-display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant {{Don't use the query SELECT _ FROM _ WHERE _ without a limit}}
+display_message('   sElEcT user fRoM myTable WhErE id > 0') # Noncompliant {{Don't use a SELECT _ FROM _ query without a limit}}
 display_message('   sElEcT user fRoM myTable WhErE id > 0 LiMiT 10')
 
-requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant {{Don't use the query SELECT _ FROM _ WHERE _ without a limit}}
+display_message(""" # Noncompliant {{Don't use a SELECT _ FROM _ query without a limit}}
+    SELECT user
+    FROM myTable
+""")
+
+display_message("""
+    SELECT user
+    FROM myTable
+    LIMIT 10
+""")
+
+requestNonCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0' # Noncompliant {{Don't use a SELECT _ FROM _ query without a limit}}
 requestCompiliant = '   SeLeCt user FrOm myTable WhErE id > 0 LiMiT 10'
 display_message(requestNonCompiliant)
 display_message(requestCompiliant)


### PR DESCRIPTION
## Summary

This Pull Request provides empirical energy measurements to justify the implementation of the rule **GCI24 - Avoid Unlimited SQL Requests** for Python. The developed rule targets SQL queries executed without a `LIMIT` clause, which forces the database engine to fetch and transfer entire result sets regardless of actual usage, leading to unnecessary CPU and DRAM consumption.

## Motivation

As part of my UNamur master's degree, I have to open a pull request on the creedengo repository and justify the developed rule with empirical and scientific methods.

## Energy Measurements

Measurements were performed on **Apple Silicon (mac)** using [**fstormacq/energyTracer**](https://github.com/fstormacq/energyTracer), a cross-platform tool that captures fine-grained per-component energy samples (CPU, GPU, ANE/CO2 eq., DRAM) for a given process.


### Code Under Test

The code under test for this experiment was the following:

```python
def main():
    import sqlite3

    try:
        connection = sqlite3.connect('src/python/data/database.sqlite')
        cursor = connection.cursor()

        REQUEST = """
            SELECT EmployeeName, JobTitle, Benefits, TotalPayBenefits, Year
            FROM Salaries 
            WHERE BasePay >= 5000
            """

        cursor.execute(REQUEST)
        _ = cursor.fetchall()
    except Exception as e:
        print(f"An error occurred: {e}")
    finally:
        if 'connection' in locals():
            connection.close()

if __name__ == "__main__":
    main()
```

with the following SQLite database: [https://www.kaggle.com/datasets/kaggle/sf-salaries](https://www.kaggle.com/datasets/kaggle/sf-salaries)

The variant without the code smell was using the following query:

```python
REQUEST = """
            SELECT  EmployeeName, JobTitle, Benefits, TotalPayBenefits, Year
            FROM Salaries 
            WHERE BasePay >= 5000
            LIMIT 10_000
            """
```

### Plots

#### Comparisons

| CPU energy consumption | RAM energy consumption |
|:-------------------------:|:--------------------------:|
| <img width="3000" height="1800" alt="cpu_energy_comparison" src="https://github.com/user-attachments/assets/ae8d340d-fb0e-4fc7-9720-0db4df49f586" /> | <img width="3000" height="1800" alt="dram_energy_comparison" src="https://github.com/user-attachments/assets/8d3ad30e-73a1-41ce-9733-4010700a5c6b" /> |

#### Box plots

| CPU box plot | RAM box plot |
|:-------------:|:-------------:|
| <img width="3000" height="1800" alt="cpu_moustache" src="https://github.com/user-attachments/assets/c562f34c-2071-4e81-8009-c746da166400" /> |  <img width="3000" height="1800" alt="dram_moustache" src="https://github.com/user-attachments/assets/10475105-8a9c-4aff-a914-34541b476205" /> |

#### Violins

| CPU violins plot | RAM violins plot |
|:----------------:|:----------------:|
| <img width="2969" height="1769" alt="cpu_violin" src="https://github.com/user-attachments/assets/a7cd5abb-3ff8-4df4-8eaf-748fa65a4234" /> | <img width="2969" height="1769" alt="dram_violin" src="https://github.com/user-attachments/assets/61a6f962-6e3e-4520-ab5c-1eb533cc4a0e" /> |


### Analysis

- **29,545 samples** collected *with* the code smell (unbounded query)
- **28,704 samples** collected *without* the code smell (query with `LIMIT`)
- Significance level: **α = 0.05**

| Metric | Δ mean | p-value | Cohen's d | Effect | Significant |
|---|---|---|---|---|---|
| `cpu_mj` | **+91.83%** | 0.00e+00 | +5.236 | large | ✅ |
| `gpu_mj` | N/A | 0.00e+00 | −0.045 | negligible | ✅ |
| `ane_mj` | +94.18% | 2.03e-113 | +0.189 | negligible | ✅ |
| `dram_mj` | **+93.70%** | 0.00e+00 | +9.383 | large | ✅ |

> Δ mean = (mean\_with − mean\_without) / mean\_with × 100. A positive value means the smell consumes more energy.

### Key Takeaways

- **CPU energy** is **~92% higher** with the smell - Cohen's d = 5.236 (large effect), indicating the processor works significantly harder to process unbounded rows.
- **DRAM energy** is **~94% higher** with the smell - Cohen's d = 9.383 (large effect), reflecting the memory pressure of loading entire result sets.
- Both effects are statistically significant with p-values at or near machine epsilon, across nearly 30,000 samples per condition, making these results highly reliable.
- GPU and ANE impacts are negligible, confirming the bottleneck is computation and memory bandwidth, not graphics or neural acceleration.

## Dataset

The raw measurements and plots are publicly available on Zenodo:

[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.19385754.svg)](https://zenodo.org/records/19385754)

## How to Reproduce

Measurements can be reproduced using [**fstormacq/energyTracer**](https://github.com/fstormacq/energyTracer) on any supported platform.

> ⚠️ Results may vary across different platforms, hardware, and devices.
