### PR TITLE
fix: Use correct path for PGDATA variable in docker-compose & update …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "data:/opt/sonarqube/data"
 
   db:
-    image: postgres:12
+    image: postgres:17
     container_name: postgresql_creedengo_python
     networks:
       - sonarnet
@@ -37,7 +37,7 @@ services:
       POSTGRES_USER: sonar
       POSTGRES_PASSWORD: sonar
       POSTGRES_DB: sonarqube
-      PGDATA: pg_data:/var/lib/postgresql/data/pgdata
+      PGDATA: /var/lib/postgresql/data/pgdata
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready -U sonar -d sonarqube" ]
       interval: 5s


### PR DESCRIPTION
PGDATA was not correctly set, causing to loose Postgres database when doing docker compose down, because it was not save in volume.

Update postgres to 17 (like creedengo-javascript).